### PR TITLE
update the root-conda docker version to latest version

### DIFF
--- a/.github/workflows/test-analysis.yml
+++ b/.github/workflows/test-analysis.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-analysis:
     runs-on: ubuntu-latest
-    container: rootproject/root:latest
+    container: rootproject/root:6.26.10-conda
 
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd /path/to/analysis/repo
 ```
 
 ```bash
-docker run -it --rm -v $PWD:/analysis -w /analysis rootproject/root-conda:6.18.04 /bin/bash
+docker run -it --rm -v $PWD:/analysis -w /analysis 6.26.00-conda /bin/bash
  ```
 
 ## Preprocessing: Reducing the initial samples

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd /path/to/analysis/repo
 ```
 
 ```bash
-docker run -it --rm -v $PWD:/analysis -w /analysis 6.26.00-conda /bin/bash
+docker run -it --rm -v $PWD:/analysis -w /analysis rootproject/root:6.26.10-conda /bin/bash
  ```
 
 ## Preprocessing: Reducing the initial samples


### PR DESCRIPTION
Hi @klieret  As discussed in #12 we need to upgrade the root docker version. Currently the recommended version is 6.18, which is no longer available.

